### PR TITLE
fix(common/Vector): fixed Vector.operate and operateAbsolute handling 0 incorrectly

### DIFF
--- a/src/common/utils/Vector.ts
+++ b/src/common/utils/Vector.ts
@@ -174,8 +174,8 @@ export class Vector {
     x = operator(x, isNumber ? b : (b.x ?? 0));
     y = operator(y, isNumber ? b : (b.y ?? 0));
 
-    if (z) z = operator(z, isNumber ? b : (b.z ?? 0));
-    if (w) w = operator(w, isNumber ? b : (b.w ?? 0));
+    if (z !== undefined) z = operator(z, isNumber ? b : (b.z ?? 0));
+    if (w !== undefined) w = operator(w, isNumber ? b : (b.w ?? 0));
 
     return this.create(x, y, z, w) as unknown as U;
   }
@@ -307,8 +307,8 @@ export class Vector {
     x = operator(Math.abs(x), isNumber ? b : Math.abs(b.x ?? 0));
     y = operator(Math.abs(y), isNumber ? b : Math.abs(b.y ?? 0));
 
-    if (z) z = operator(Math.abs(z), isNumber ? b : Math.abs(b.z ?? 0));
-    if (w) w = operator(Math.abs(w), isNumber ? b : Math.abs(b.w ?? 0));
+    if (z !== undefined) z = operator(Math.abs(z), isNumber ? b : Math.abs(b.z ?? 0));
+    if (w !== undefined) w = operator(Math.abs(w), isNumber ? b : Math.abs(b.w ?? 0));
 
     return this.create(x, y, z, w) as unknown as U;
   }
@@ -569,8 +569,8 @@ export class Vector {
   /**
    * @see Vector.addY
    */
-  public addY(x: number) {
-    return Vector.addY(this, x);
+  public addY(y: number) {
+    return Vector.addY(this, y);
   }
 
   /**


### PR DESCRIPTION
This PR fixes the vector operations, such as `add` resulting in incorrect vectors, when `z` or `w` is 0 on the vector we are adding to.

```typescript
import { Vector4 } from '../../src/common';

const v1 = new Vector4(1, 2, 0, 0);
const v2 = new Vector4(2, 2, 2, 2);
const result = v1.add(v2);
console.log(result.x, result.y, result.z, result.w); // actual result: 3, 4, 0, 0 | expected result: 3, 4, 2, 2
```

BTW, Your contributing guidelines mention creating PR against `development` branch, but that does not exist