### PR TITLE
fix(client/Model): fixed Model.request timeout comparison being flipped

### DIFF
--- a/src/client/Model.ts
+++ b/src/client/Model.ts
@@ -200,7 +200,7 @@ export class Model {
    * This function will not automatically set the model as no longer needed when
    * done.
    *
-   * @param timeout Maximum allowed time for model to load.
+   * @param timeoutMs Maximum allowed time for model to load.
    */
   public async request(timeoutMs = 1000): Promise<boolean> {
     if (!this.IsInCdImage && !this.IsValid && !IsWeaponValid(this.hash)) {
@@ -212,7 +212,7 @@ export class Model {
     }
     RequestModel(this.hash);
     const timeout = GetGameTimer() + timeoutMs;
-    while (!this.IsLoaded && timeout < GetGameTimer()) {
+    while (!this.IsLoaded && GetGameTimer() < timeout) {
       await Wait(0);
     }
     return this.IsLoaded;


### PR DESCRIPTION
Corrected the timeout comparison in Model.request to ensure the loop exits when the timeout is reached.
Previously, the condition checked if the timeout timestamp is greater than current timestamp, which is always true on the first check, resulting in premature loop termination.