### PR TITLE
Update Vector.ts

### DIFF
--- a/src/common/utils/Vector.ts
+++ b/src/common/utils/Vector.ts
@@ -828,7 +828,7 @@ export class Vector4 extends Vector {
    */
   constructor(x: number, y = x, z = y, w = z) {
     super(x, y, z, w);
-    this.z = w;
+    this.z = z;
     this.w = w;
   }
 


### PR DESCRIPTION
When processing a Vector4 in FiveM, specifically in a resource called ox_core, the w value (representing heading) is incorrectly assigned to the z value (which should represent elevation/height). TypeScript is baked into their code, and this issue may affect other files using Vector4.